### PR TITLE
feat: Implement credit-based viewing system

### DIFF
--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -227,4 +227,6 @@ dependencies {
     //implementation 'com.github.stfalcon-studio:Chatkit:' + chatkitVersion
 
     implementation 'net.gotev:speech:' + gotevSpeechVersion
+
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }

--- a/smarttubetv/src/main/AndroidManifest.xml
+++ b/smarttubetv/src/main/AndroidManifest.xml
@@ -152,6 +152,12 @@
             android:screenOrientation="unspecified"/>
 
         <activity
+            android:name="com.liskovsoft.smartyoutubetv2.tv.ui.main.WebViewActivity"
+            android:launchMode="singleInstance"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|layoutDirection"
+            android:screenOrientation="unspecified"/>
+
+        <activity
             android:name="com.liskovsoft.smartyoutubetv2.tv.ui.channel.ChannelActivity"
             android:launchMode="singleInstance"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|layoutDirection"

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/UserStateManager.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/UserStateManager.java
@@ -1,0 +1,42 @@
+package com.liskovsoft.smartyoutubetv2.common.misc;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.UUID;
+
+public class UserStateManager {
+    private static final String PREF_NAME = "user_state";
+    private static final String KEY_USER_ID = "user_id";
+    private static final String KEY_CREDIT_STATUS = "credit_status";
+    private static final String STATUS_EXHAUSTED = "exhausted";
+
+    private static UserStateManager sInstance;
+    private final SharedPreferences mPrefs;
+
+    private UserStateManager(Context context) {
+        mPrefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        if (getUserId() == null) {
+            // Generate and store a new user ID if one doesn't exist
+            mPrefs.edit().putString(KEY_USER_ID, UUID.randomUUID().toString()).apply();
+        }
+    }
+
+    public static synchronized UserStateManager getInstance(Context context) {
+        if (sInstance == null) {
+            sInstance = new UserStateManager(context.getApplicationContext());
+        }
+        return sInstance;
+    }
+
+    public String getUserId() {
+        return mPrefs.getString(KEY_USER_ID, null);
+    }
+
+    public boolean areCreditsExhausted() {
+        return STATUS_EXHAUSTED.equals(mPrefs.getString(KEY_CREDIT_STATUS, ""));
+    }
+
+    public void setCreditsStatus(String status) {
+        mPrefs.edit().putString(KEY_CREDIT_STATUS, status).apply();
+    }
+}

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/browse/video/VideoGridFragment.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/browse/video/VideoGridFragment.java
@@ -15,6 +15,7 @@ import com.liskovsoft.smartyoutubetv2.common.app.models.data.VideoGroup;
 import com.liskovsoft.smartyoutubetv2.common.app.presenters.BrowsePresenter;
 import com.liskovsoft.smartyoutubetv2.common.app.presenters.interfaces.VideoGroupPresenter;
 import com.liskovsoft.smartyoutubetv2.common.misc.TickleManager;
+import com.liskovsoft.smartyoutubetv2.common.misc.UserStateManager;
 import com.liskovsoft.smartyoutubetv2.common.prefs.MainUIData;
 import com.liskovsoft.smartyoutubetv2.common.utils.LoadingManager;
 import com.liskovsoft.smartyoutubetv2.tv.R;
@@ -257,6 +258,11 @@ public class VideoGridFragment extends GridFragment implements VideoSection {
                                   RowPresenter.ViewHolder rowViewHolder, Row row) {
 
             if (item instanceof Video) {
+                UserStateManager userStateManager = UserStateManager.getInstance(getActivity());
+                if (userStateManager.areCreditsExhausted()) {
+                    Toast.makeText(getActivity(), "Out of credits. Please top up.", Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 mMainPresenter.onVideoItemClicked((Video) item);
             } else {
                 Toast.makeText(getActivity(), item.toString(), Toast.LENGTH_SHORT).show();

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/SplashActivity.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/SplashActivity.java
@@ -2,14 +2,25 @@ package com.liskovsoft.smartyoutubetv2.tv.ui.main;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import com.liskovsoft.smartyoutubetv2.common.app.presenters.SplashPresenter;
 import com.liskovsoft.smartyoutubetv2.common.app.views.SplashView;
 import com.liskovsoft.smartyoutubetv2.common.misc.MotherActivity;
+import com.liskovsoft.smartyoutubetv2.common.misc.UserStateManager;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.io.IOException;
 
 public class SplashActivity extends MotherActivity implements SplashView {
     private static final String TAG = SplashActivity.class.getSimpleName();
     private Intent mNewIntent;
     private SplashPresenter mPresenter;
+    private UserStateManager mUserStateManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -20,6 +31,9 @@ public class SplashActivity extends MotherActivity implements SplashView {
         mPresenter = SplashPresenter.instance(this);
         mPresenter.setView(this);
         mPresenter.onViewInitialized();
+
+        mUserStateManager = UserStateManager.getInstance(this);
+        checkUserCredits();
 
         //finish();
     }
@@ -52,5 +66,54 @@ public class SplashActivity extends MotherActivity implements SplashView {
             // NullPointerException: Attempt to invoke virtual method 'void com.android.server.wm.DisplayContent.moveStack(com.android.server.wm.TaskStack, boolean)'
             e.printStackTrace();
         }
+    }
+
+    private void checkUserCredits() {
+        String userId = mUserStateManager.getUserId();
+        if (userId == null) {
+            return;
+        }
+
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder()
+                .url("https://your-credit-server.com/api/v1/check_credits?id=" + userId)
+                .build();
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                // Log the error or show a toast to the user
+                Log.e(TAG, "Failed to check credits", e);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if (!response.isSuccessful()) {
+                    // Log the error or show a toast to the user
+                    Log.e(TAG, "Failed to check credits: " + response);
+                    return;
+                }
+
+                try {
+                    String responseBody = response.body().string();
+                    JSONObject json = new JSONObject(responseBody);
+                    String status = json.optString("status");
+                    mUserStateManager.setCreditsStatus(status);
+
+                    if ("exhausted".equals(status)) {
+                        runOnUiThread(() -> showCreditsExhaustedUI());
+                    }
+                } catch (JSONException e) {
+                    // Log the error or show a toast to the user
+                    Log.e(TAG, "Failed to parse credit check response", e);
+                }
+            }
+        });
+    }
+
+    private void showCreditsExhaustedUI() {
+        Intent intent = new Intent(this, WebViewActivity.class);
+        intent.putExtra(WebViewActivity.EXTRA_URL, "https://your-credit-server.com/top_up");
+        startActivity(intent);
     }
 }

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/WebViewActivity.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/WebViewActivity.java
@@ -1,0 +1,26 @@
+package com.liskovsoft.smartyoutubetv2.tv.ui.main;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import com.liskovsoft.smartyoutubetv2.tv.R;
+
+public class WebViewActivity extends Activity {
+    public static final String EXTRA_URL = "extra_url";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_webview);
+
+        WebView webView = findViewById(R.id.webview);
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.setWebViewClient(new WebViewClient());
+
+        String url = getIntent().getStringExtra(EXTRA_URL);
+        if (url != null) {
+            webView.loadUrl(url);
+        }
+    }
+}

--- a/smarttubetv/src/main/res/layout/activity_webview.xml
+++ b/smarttubetv/src/main/res/layout/activity_webview.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</RelativeLayout>


### PR DESCRIPTION
This commit introduces a credit-based viewing system to the SmartTube app.

The system includes:
- A `UserStateManager` class to manage a unique user ID and credit status using SharedPreferences.
- A `WebViewActivity` to display a web page for topping up credits.
- A credit check in `SplashActivity` on app startup, which makes a network request to a credit server.
- Playback blocking in `VideoGridFragment` if the user's credits are exhausted.

The implementation is designed to be minimally invasive, offloading UI and payment logic to an external web server.